### PR TITLE
Add fallback color for metric values

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -371,6 +371,7 @@ p {
 .metric-value {
   font-size: 2.5rem;
   font-weight: 800;
+  color: var(--primary-color);
   background: linear-gradient(135deg, var(--primary-color), var(--secondary-color));
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;


### PR DESCRIPTION
## Summary
- ensure `.metric-value` displays numbers on browsers without `background-clip: text`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6850480188048331bd79be01765f99ec