### PR TITLE
Fix CSS background-opacity usage

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -90,8 +90,7 @@ td {
 }
 
 tr:hover td {
-    background: var(--primary-color);
-    background-opacity: 0.02;
+    background: rgba(37, 99, 235, 0.02);
     color: var(--gray-900);
 }
 
@@ -100,8 +99,7 @@ tr:nth-child(even) td {
 }
 
 tr:nth-child(even):hover td {
-    background: var(--primary-color);
-    background-opacity: 0.05;
+    background: rgba(37, 99, 235, 0.05);
 }
 
 .currency-pln {

--- a/css/styles.css
+++ b/css/styles.css
@@ -295,17 +295,17 @@ p {
   transform: rotate(15deg);
 }
 
-.file-upload:hover, .file-upload.drag-over {
+
+.file-upload:hover,
+.file-upload.drag-over {
   border-color: var(--primary-color);
-  background: var(--primary-color);
-  background-opacity: 0.05;
+  background: rgba(37, 99, 235, 0.05);
   transform: scale(1.02);
 }
 
 .file-upload.drag-over {
   border-color: var(--secondary-color);
-  background: var(--secondary-color);
-  background-opacity: 0.1;
+  background: rgba(16, 185, 129, 0.1);
   box-shadow: var(--shadow-xl);
 }
 


### PR DESCRIPTION
## Summary
- replace invalid `background-opacity` rules with rgba backgrounds in `styles.css`
- fix table row hover background styles in `components.css`

## Testing
- `grep -n "background-opacity" -n css/styles.css css/components.css`

------
https://chatgpt.com/codex/tasks/task_e_685048c687e08331a1f8b2e76ae770dc