### PR TITLE
Add full-width class for dashboard tables

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -396,6 +396,9 @@ p {
   gap: var(--spacing-2xl);
   margin-bottom: var(--spacing-2xl);
 }
+.dashboard.full-width {
+  grid-template-columns: 1fr;
+}
 
 /* ===== UTILITY CLASSES ===== */
 .sr-only {

--- a/index.html
+++ b/index.html
@@ -167,7 +167,7 @@
             </div>
 
             <!-- Performance Tables -->
-            <div class="dashboard">
+            <div class="dashboard full-width">
                 <!-- Campaign Performance Table -->
                 <section class="card" aria-labelledby="campaign-table-heading">
                     <h3 id="campaign-table-heading">Campaign Performance</h3>
@@ -219,7 +219,7 @@
             </div>
 
             <!-- Audience Segment Analysis -->
-            <div class="dashboard">
+            <div class="dashboard full-width">
                 <!-- First Party Segments -->
                 <section class="card" aria-labelledby="fp-segments-heading">
                     <h3 id="fp-segments-heading">1st Party Audience Segments</h3>


### PR DESCRIPTION
## Summary
- add optional full-width layout for dashboards
- apply the full-width layout to tables in index.html

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685049450c2883319f6bcf5cd32682b9