### PR TITLE
Add keyboard upload access

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -45,7 +45,18 @@ function initializeUpload() {
     dropZone.addEventListener('click', function(e) {
         e.preventDefault();
         console.log('Drop zone clicked');
+        // Ensure the hidden input gains focus before triggering the file dialog
+        fileInput.focus();
         fileInput.click();
+    });
+
+    // Keyboard accessibility - trigger click on Enter or Space
+    dropZone.addEventListener('keydown', function(e) {
+        if (e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar') {
+            e.preventDefault();
+            fileInput.focus();
+            fileInput.click();
+        }
     });
     
     // File input change


### PR DESCRIPTION
## Summary
- add keyboard accessibility on the file drop zone
- focus hidden file input before opening the dialog

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68504fff34dc83319fe836898d95fe84